### PR TITLE
Remove work phases from issue_template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -5,12 +5,3 @@
 ## it's done when …
 - [ ] thing
 - [ ] and another thing
-
-## phases 
-- [ ] content
-- [ ] wireframing/iA
-- [ ] give it a look and feel 
-- [ ] translate into code
-- [ ] testing
-- [ ] push to live site
-- [ ] rapid validation / usability testing

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 _site/
 .sass-cache/
+.DS_Store


### PR DESCRIPTION
Since we decided to break out the work tasks differently than what I had originally assumed, we don't need this section in the issue template and it's just making life a tiny bit harder, which we don't want. 