### PR TITLE
Move privacy statement to an include

### DIFF
--- a/_develop/about-10x/index.html
+++ b/_develop/about-10x/index.html
@@ -207,13 +207,15 @@
 
 <h2 class="docs-h2">10x privacy policy</h2>
 
-<h3 id="information-you-send-us-as-an-idea">Information you send us as an idea</h3>
+<h3 id="information-you-send-us-as-a-pitch">Information you send us as a pitch</h3>
+
 <p>Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to <a href="mailto:10x@gsa.gov">10x@gsa.gov</a> or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.</p>
 
 <p>We cannot accept ideas from the general public. If you are <strong>not</strong> a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.</p>
 
 <h3 id="everything-else">Everything else</h3>
 <p>For everything else, we follow the practices outlined in GSA’s <a href="https://www.gsa.gov/website-information/privacy-and-security-notice">privacy and security notice</a>.</p>
+
 
 </article>
 

--- a/_develop/privacy-policy/index.html
+++ b/_develop/privacy-policy/index.html
@@ -185,13 +185,13 @@
   <div class="padding-x-2 max-width-tablet-plus margin-x-auto line-height-large tablet:padding-x-5">
 
 <article class="usa-body-content padding-x-0 max-width-tablet-plus margin-x-auto line-height-large color-90">
-    <h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Information you send us as a pitch</h2>
+    <h2 id="information-you-send-us-as-a-pitch">Information you send us as a pitch</h2>
 
 <p>Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to <a href="mailto:10x@gsa.gov">10x@gsa.gov</a> or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.</p>
 
 <p>We cannot accept ideas from the general public. If you are <strong>not</strong> a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.</p>
 
-<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Everything else</h2>
+<h3 id="everything-else">Everything else</h3>
 <p>For everything else, we follow the practices outlined in GSA’s <a href="https://www.gsa.gov/website-information/privacy-and-security-notice">privacy and security notice</a>.</p>
 
 </article>

--- a/_includes/privacy-policy.md
+++ b/_includes/privacy-policy.md
@@ -1,0 +1,8 @@
+<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Information you send us as a pitch</h2>
+
+Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to [{{ site.email }}](mailto:{{ site.email }}) or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.
+
+We cannot accept ideas from the general public. If you are **not** a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.
+
+<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Everything else</h2>
+For everything else, we follow the practices outlined in GSA’s [privacy and security notice](https://www.gsa.gov/website-information/privacy-and-security-notice).

--- a/_includes/privacy-policy.md
+++ b/_includes/privacy-policy.md
@@ -1,8 +1,7 @@
-<h2>Information you send us as a pitch</h2>
 
 Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to [{{ site.email }}](mailto:{{ site.email }}) or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.
 
 We cannot accept ideas from the general public. If you are **not** a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.
 
-<h2>Everything else</h2>
+### Everything else
 For everything else, we follow the practices outlined in GSA’s [privacy and security notice](https://www.gsa.gov/website-information/privacy-and-security-notice).

--- a/_includes/privacy-policy.md
+++ b/_includes/privacy-policy.md
@@ -1,8 +1,8 @@
-<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Information you send us as a pitch</h2>
+<h2>Information you send us as a pitch</h2>
 
 Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to [{{ site.email }}](mailto:{{ site.email }}) or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.
 
 We cannot accept ideas from the general public. If you are **not** a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.
 
-<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Everything else</h2>
+<h2>Everything else</h2>
 For everything else, we follow the practices outlined in GSA’s [privacy and security notice](https://www.gsa.gov/website-information/privacy-and-security-notice).

--- a/_pages/about-10x.md
+++ b/_pages/about-10x.md
@@ -30,12 +30,10 @@ As we scale this program, 10x will be open to submissions from the entire federa
 
 {% endif %}
 
+
+
 <h2 class="docs-h2">10x privacy policy</h2>
 
-### Information you send us as an idea
-Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to [{{ site.email }}](mailto:{{ site.email }}) or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.
+### Information you send us as a pitch
 
-We cannot accept ideas from the general public. If you are **not** a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.
-
-### Everything else
-For everything else, we follow the practices outlined in GSA’s [privacy and security notice](https://www.gsa.gov/website-information/privacy-and-security-notice).  
+{% include privacy-policy.md %}

--- a/_pages/privacy-policy.md
+++ b/_pages/privacy-policy.md
@@ -9,11 +9,7 @@ graphic_inner_bg: indigo-warm-30
 show_navbar: true
 ---
 
-<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Information you send us as a pitch</h2>
+## Information you send us as a pitch
 
-Federal employees can voluntarily send us information as part of an idea submission for 10x funding by sending an email message to [{{ site.email }}](mailto:{{ site.email }}) or by submitting a project idea through our online form. This information will be shared with subject-matter experts and the 10x Program Advisory Board in order to make funding decisions. We publish information about which ideas do and do not receive funding, along with the date of submission and the organization where the idea originated from. If your idea is accepted for funding, your name and home agency will be listed on our website. In some cases, we might feature your actual idea on our website for teaching and promotion purposes.
 
-We cannot accept ideas from the general public. If you are **not** a federal employee and you submit an idea for funding, we’ll only use your information to reply to your message. We will not keep the information you sent as part of your idea.
-
-<h2 class="margin-bottom-5 border-top-p5 padding-top-2 margin-top-5">Everything else</h2>
-For everything else, we follow the practices outlined in GSA’s [privacy and security notice](https://www.gsa.gov/website-information/privacy-and-security-notice).  
+{% include privacy-policy.md %}


### PR DESCRIPTION
Currently the site has the privacy statement language in two places. 

In order to make sure the two statements are consistent between each other, this PR moves the language to an include that is then placed into both the `about` page and the `privacy policy` page. 

No changes to the content were made in this PR. BC the heading levels are different between the about page and the privacy policy page, the first heading is left out of the include and instead is in the markup for each page. That means that on the `about` page, both that heading and the second (
"everything else") are h3. On the privacy policy page, the first heading is an h2, while the second heading is an h3. This is technically not 100 percent correct but it's also not 100 percent wrong, but would be overly complicated to fix.  ¯\\_(ツ)_/¯