### PR TITLE
Create .npmrc to inhibit Chromium downloading

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+puppeteer_skip_chromium_download=true


### PR DESCRIPTION
There are space concerns associated with the 10x website build on Federalist.  Brian Hurst suggested inhibiting the (re-)downloading of Chromium which is already present in the build containers:

https://gsa-tts.slack.com/archives/C1NUUGTT5/p1653055176807739?thread_ts=1653052608.668679&cid=C1NUUGTT5

He also provided a link to an issue that may be related:

puppeteer/puppeteer#2270 (comment)